### PR TITLE
Corrects formatting in /C/Readme.md

### DIFF
--- a/C/Readme.md
+++ b/C/Readme.md
@@ -34,5 +34,6 @@ Nevertheless, if you want to try it out quickly, simply run:
 	LaJHjmVu8_~po#smR+a~xaoLWCRj
 
 If you want to try out the decoder, simply run:
+
 	$ make blurhash_decoder
 	$ ./blurhash_decoder "LaJHjmVu8_~po#smR+a~xaoLWCRj" 32 32 decoded_output.png


### PR DESCRIPTION
CLI Decoder usage was not rendering as a code block, and there were unescaped strikethrough.

Before:
![image](https://user-images.githubusercontent.com/8635304/118535436-b688ba00-b707-11eb-8312-3c332bf66247.png)

After:
![image](https://user-images.githubusercontent.com/8635304/118535467-be485e80-b707-11eb-8fea-7920cd04633d.png)
